### PR TITLE
fix: esbuild build error `empty glob` on export in `bindings.js`

### DIFF
--- a/binding.js
+++ b/binding.js
@@ -1,4 +1,4 @@
 const buildType = process.config.target_defaults
   ? process.config.target_defaults.default_configuration
   : /* istanbul ignore next */ 'Release';
-module.exports = require(`./build/${buildType}/binding`);
+module.exports = require(`node_modules/zstd-napi/build/${buildType}/binding`);


### PR DESCRIPTION
I managed to fix my issue in #140 by simply using an absolute `node_modules` export instead of a relative export. This approach should also be more robust across multiple bundlers. 